### PR TITLE
Nissix plugin scope-packages on wix-stack1

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const bootstrap = require('wix-bootstrap-ng');
+const bootstrap = require('@wix/wix-bootstrap-ng');
 
 const rootDir = process.env.SRC_PATH || './dist/src';
 const getPath = filename => path.join(rootDir, filename);

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "enzyme": "^2.3.0",
     "jsdom-global": "^2.1.0",
     "nock": "^8.0.0",
-    "wix-bootstrap-testkit": "latest",
-    "wix-config-emitter": "latest",
+    "@wix/wix-bootstrap-testkit": "latest",
+    "@wix/wix-config-emitter": "latest",
     "husky": "^0.13.4",
-    "yoshi": "latest"
+    "@wix/yoshi": "latest"
   },
   "dependencies": {
     "axios": "^0.15.2",
@@ -44,11 +44,11 @@
     "react-dom": "^15.5.0",
     "react-i18next": "^3.1.0",
     "react-youtube": "^7.4.0",
-    "wix-axios-config": "latest",
-    "wix-bootstrap-ng": "latest",
-    "wix-express-rendering-model": "latest",
-    "wix-renderer": "latest",
-    "wix-run-mode": "latest",
+    "@wix/wix-axios-config": "latest",
+    "@wix/wix-bootstrap-ng": "latest",
+    "@wix/wix-express-rendering-model": "latest",
+    "@wix/wix-renderer": "latest",
+    "@wix/wix-run-mode": "latest",
     "wix-style-react": "^1.1.2071"
   },
   "babel": {

--- a/src/client.js
+++ b/src/client.js
@@ -3,7 +3,7 @@ import React from 'react';
 import axios from 'axios';
 import ReactDOM from 'react-dom';
 import {I18nextProvider} from 'react-i18next';
-import {wixAxiosConfig} from 'wix-axios-config';
+import {wixAxiosConfig} from '@wix/wix-axios-config';
 import App from './components/App';
 import i18n from './i18n';
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,7 @@
 import 'babel-polyfill';
-import wixRenderer from 'wix-renderer';
-import wixRunMode from 'wix-run-mode';
-import wixExpressRenderingModel from 'wix-express-rendering-model';
+import wixRenderer from '@wix/wix-renderer';
+import wixRunMode from '@wix/wix-run-mode';
+import wixExpressRenderingModel from '@wix/wix-express-rendering-model';
 
 module.exports = (app, context) => {
   const config = context.config.load('wix-stack1');

--- a/test/environment.js
+++ b/test/environment.js
@@ -1,5 +1,5 @@
-import testkit from 'wix-bootstrap-testkit';
-import configEmitter from 'wix-config-emitter';
+import testkit from '@wix/wix-bootstrap-testkit';
+import configEmitter from '@wix/wix-config-emitter';
 
 export const app = bootstrapServer();
 

--- a/test/mocha-setup.js
+++ b/test/mocha-setup.js
@@ -5,6 +5,6 @@ const virtualConsole = require('jsdom').createVirtualConsole().sendTo(console);
 require('jsdom-global')(undefined, {url: getTestBaseUrl(), virtualConsole});
 
 const axios = require('axios');
-const {wixAxiosConfig} = require('wix-axios-config');
+const {wixAxiosConfig} = require('@wix/wix-axios-config');
 
 wixAxiosConfig(axios, {baseURL: getTestBaseUrl()});

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,1 +1,1 @@
-module.exports = require('yoshi/config/wallaby-mocha');
+module.exports = require('@wix/yoshi/config/wallaby-mocha');


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 6.804s



Output Log:
Migrating package "wix-stack1" in .


## Migration from non scope to @wix/scoped packages
> /tmp/cbb74d3e7edf750ad22dc3dacf89318b

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
index.js
wallaby.js
src/client.js
src/server.js
test/environment.js
test/mocha-setup.js
```

